### PR TITLE
refactor: migrate micro-frontends to Remix runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# remix-frontend
+# Remix Micro Frontends
+
+This repo showcases a Remix-based micro-frontend architecture with a shell application (**ScaleShell**) and three child apps (**ProduceScale**, **ColleagueMenu**, and **Notification**).  The shell loads each child at runtime via Vite Module Federation, routes with XState, and shares state through a Zustand store.
+
+## Local development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Build the child apps so their federated modules are available to the shell:
+   ```bash
+   npm --prefix apps/scale-shell run build:remotes
+   ```
+3. Start the shell:
+   ```bash
+   npm --prefix apps/scale-shell run dev          # http://localhost:3000
+   ```
+4. Open http://localhost:3000 to interact with the shell application.
+
+## Production
+
+### Build all apps
+
+Build the shell. This command also compiles the child applications and copies their `remoteEntry.js` files into the shell's `public` directory:
+```bash
+npm run build:shell
+```
+
+### Run with Docker
+
+The `apps/scale-shell` folder contains a Dockerfile for serving the shell and all child apps in production.  Build and run it from the repo root:
+```bash
+docker build -t scale-shell -f apps/scale-shell/Dockerfile .
+docker run -p 3000:3000 scale-shell
+```
+
+The shell is available at http://localhost:3000 and serves the child applications' federated bundles locally.

--- a/apps/colleague-menu/app/entry.client.tsx
+++ b/apps/colleague-menu/app/entry.client.tsx
@@ -1,0 +1,12 @@
+import { RemixBrowser } from "@remix-run/react";
+import { hydrateRoot } from "react-dom/client";
+import { StrictMode, startTransition } from "react";
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>
+  );
+});

--- a/apps/colleague-menu/app/entry.server.tsx
+++ b/apps/colleague-menu/app/entry.server.tsx
@@ -1,0 +1,21 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext
+) {
+  const markup = renderToString(
+    <RemixServer context={remixContext} url={request.url} />
+  );
+
+  responseHeaders.set("Content-Type", "text/html");
+
+  return new Response(`<!DOCTYPE html>${markup}`, {
+    status: responseStatusCode,
+    headers: responseHeaders
+  });
+}

--- a/apps/colleague-menu/app/remote.tsx
+++ b/apps/colleague-menu/app/remote.tsx
@@ -1,0 +1,1 @@
+export { default } from './routes/_index';

--- a/apps/colleague-menu/app/root.tsx
+++ b/apps/colleague-menu/app/root.tsx
@@ -1,0 +1,18 @@
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
+
+export default function Root() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}

--- a/apps/colleague-menu/app/routes/_index.tsx
+++ b/apps/colleague-menu/app/routes/_index.tsx
@@ -1,0 +1,11 @@
+import { useSharedState } from 'shared-state';
+
+export default function ColleagueMenu() {
+  const shared = useSharedState();
+  return (
+    <div>
+      <h2>ColleagueMenu App</h2>
+      <button onClick={() => shared.increment()}>Increment</button>
+    </div>
+  );
+}

--- a/apps/colleague-menu/package.json
+++ b/apps/colleague-menu/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "colleague-menu",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "remix dev",
+    "build": "remix build && vite build",
+    "start": "remix-serve build"
+  },
+  "dependencies": {
+    "@remix-run/node": "^2.0.0",
+    "@remix-run/react": "^2.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "shared-state": "1.0.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "^1.0.0",
+    "@remix-run/dev": "^2.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/apps/colleague-menu/remix.config.js
+++ b/apps/colleague-menu/remix.config.js
@@ -1,0 +1,4 @@
+/** @type {import('@remix-run/dev').AppConfig} */
+module.exports = {
+  ignoredRouteFiles: ['**/.*']
+};

--- a/apps/colleague-menu/vite.config.ts
+++ b/apps/colleague-menu/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import federation from '@module-federation/vite';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    federation({
+      name: 'colleagueMenu',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './App': './app/remote.tsx',
+      },
+      shared: ['react', 'react-dom', 'zustand'],
+    }),
+  ],
+  build: {
+    outDir: 'dist',
+    target: 'esnext',
+  },
+});

--- a/apps/notification/app/entry.client.tsx
+++ b/apps/notification/app/entry.client.tsx
@@ -1,0 +1,12 @@
+import { RemixBrowser } from "@remix-run/react";
+import { hydrateRoot } from "react-dom/client";
+import { StrictMode, startTransition } from "react";
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>
+  );
+});

--- a/apps/notification/app/entry.server.tsx
+++ b/apps/notification/app/entry.server.tsx
@@ -1,0 +1,21 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext
+) {
+  const markup = renderToString(
+    <RemixServer context={remixContext} url={request.url} />
+  );
+
+  responseHeaders.set("Content-Type", "text/html");
+
+  return new Response(`<!DOCTYPE html>${markup}`, {
+    status: responseStatusCode,
+    headers: responseHeaders
+  });
+}

--- a/apps/notification/app/remote.tsx
+++ b/apps/notification/app/remote.tsx
@@ -1,0 +1,1 @@
+export { default } from './routes/_index';

--- a/apps/notification/app/root.tsx
+++ b/apps/notification/app/root.tsx
@@ -1,0 +1,18 @@
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
+
+export default function Root() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}

--- a/apps/notification/app/routes/_index.tsx
+++ b/apps/notification/app/routes/_index.tsx
@@ -1,0 +1,11 @@
+import { useSharedState } from 'shared-state';
+
+export default function Notification() {
+  const shared = useSharedState();
+  return (
+    <div>
+      <h2>Notification App</h2>
+      <button onClick={() => shared.increment()}>Increment</button>
+    </div>
+  );
+}

--- a/apps/notification/package.json
+++ b/apps/notification/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "notification",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "remix dev",
+    "build": "remix build && vite build",
+    "start": "remix-serve build"
+  },
+  "dependencies": {
+    "@remix-run/node": "^2.0.0",
+    "@remix-run/react": "^2.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "shared-state": "1.0.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "^1.0.0",
+    "@remix-run/dev": "^2.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/apps/notification/remix.config.js
+++ b/apps/notification/remix.config.js
@@ -1,0 +1,4 @@
+/** @type {import('@remix-run/dev').AppConfig} */
+module.exports = {
+  ignoredRouteFiles: ['**/.*']
+};

--- a/apps/notification/vite.config.ts
+++ b/apps/notification/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import federation from '@module-federation/vite';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    federation({
+      name: 'notification',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './App': './app/remote.tsx',
+      },
+      shared: ['react', 'react-dom', 'zustand'],
+    }),
+  ],
+  build: {
+    outDir: 'dist',
+    target: 'esnext',
+  },
+});

--- a/apps/produce-scale/app/entry.client.tsx
+++ b/apps/produce-scale/app/entry.client.tsx
@@ -1,0 +1,12 @@
+import { RemixBrowser } from "@remix-run/react";
+import { hydrateRoot } from "react-dom/client";
+import { StrictMode, startTransition } from "react";
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>
+  );
+});

--- a/apps/produce-scale/app/entry.server.tsx
+++ b/apps/produce-scale/app/entry.server.tsx
@@ -1,0 +1,21 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext
+) {
+  const markup = renderToString(
+    <RemixServer context={remixContext} url={request.url} />
+  );
+
+  responseHeaders.set("Content-Type", "text/html");
+
+  return new Response(`<!DOCTYPE html>${markup}`, {
+    status: responseStatusCode,
+    headers: responseHeaders
+  });
+}

--- a/apps/produce-scale/app/remote.tsx
+++ b/apps/produce-scale/app/remote.tsx
@@ -1,0 +1,1 @@
+export { default } from './routes/_index';

--- a/apps/produce-scale/app/root.tsx
+++ b/apps/produce-scale/app/root.tsx
@@ -1,0 +1,18 @@
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
+
+export default function Root() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}

--- a/apps/produce-scale/app/routes/_index.tsx
+++ b/apps/produce-scale/app/routes/_index.tsx
@@ -1,0 +1,11 @@
+import { useSharedState } from 'shared-state';
+
+export default function ProduceScale() {
+  const shared = useSharedState();
+  return (
+    <div>
+      <h2>ProduceScale App</h2>
+      <button onClick={() => shared.increment()}>Increment</button>
+    </div>
+  );
+}

--- a/apps/produce-scale/package.json
+++ b/apps/produce-scale/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "produce-scale",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "remix dev",
+    "build": "remix build && vite build",
+    "start": "remix-serve build"
+  },
+  "dependencies": {
+    "@remix-run/node": "^2.0.0",
+    "@remix-run/react": "^2.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "shared-state": "1.0.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "^1.0.0",
+    "@remix-run/dev": "^2.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/apps/produce-scale/remix.config.js
+++ b/apps/produce-scale/remix.config.js
@@ -1,0 +1,4 @@
+/** @type {import('@remix-run/dev').AppConfig} */
+module.exports = {
+  ignoredRouteFiles: ['**/.*']
+};

--- a/apps/produce-scale/vite.config.ts
+++ b/apps/produce-scale/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import federation from '@module-federation/vite';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    federation({
+      name: 'produceScale',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './App': './app/remote.tsx',
+      },
+      shared: ['react', 'react-dom', 'zustand'],
+    }),
+  ],
+  build: {
+    outDir: 'dist',
+    target: 'esnext',
+  },
+});

--- a/apps/scale-shell/Dockerfile
+++ b/apps/scale-shell/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-alpine
+WORKDIR /app
+
+# Copy repo and install all workspaces
+COPY . .
+RUN npm install
+
+# Build shell along with child apps
+RUN npm run build:shell
+
+# Start the Remix server
+CMD ["npm", "--prefix", "apps/scale-shell", "run", "start"]

--- a/apps/scale-shell/app/entry.client.tsx
+++ b/apps/scale-shell/app/entry.client.tsx
@@ -1,0 +1,12 @@
+import { RemixBrowser } from "@remix-run/react";
+import { hydrateRoot } from "react-dom/client";
+import { StrictMode, startTransition } from "react";
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>
+  );
+});

--- a/apps/scale-shell/app/entry.server.tsx
+++ b/apps/scale-shell/app/entry.server.tsx
@@ -1,0 +1,21 @@
+import type { EntryContext } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
+import { renderToString } from "react-dom/server";
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext
+) {
+  const markup = renderToString(
+    <RemixServer context={remixContext} url={request.url} />
+  );
+
+  responseHeaders.set("Content-Type", "text/html");
+
+  return new Response(`<!DOCTYPE html>${markup}`, {
+    status: responseStatusCode,
+    headers: responseHeaders
+  });
+}

--- a/apps/scale-shell/app/navigationMachine.test.ts
+++ b/apps/scale-shell/app/navigationMachine.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { interpret } from 'xstate';
+import { navigationMachine } from './navigationMachine';
+
+describe('navigation state machine', () => {
+  it('navigates between shell and produce scale', () => {
+    const service = interpret(navigationMachine).start();
+    expect(service.state.value).toBe('shell');
+    service.send('PRODUCE');
+    expect(service.state.value).toBe('produceScale');
+    service.send('SHELL');
+    expect(service.state.value).toBe('shell');
+  });
+});

--- a/apps/scale-shell/app/navigationMachine.ts
+++ b/apps/scale-shell/app/navigationMachine.ts
@@ -1,0 +1,18 @@
+import { createMachine } from 'xstate';
+
+export const navigationMachine = createMachine({
+  id: 'navigation',
+  initial: 'shell',
+  states: {
+    shell: {
+      on: {
+        PRODUCE: 'produceScale',
+        COLLEAGUE: 'colleagueMenu',
+        NOTIFICATION: 'notification'
+      }
+    },
+    produceScale: { on: { SHELL: 'shell' } },
+    colleagueMenu: { on: { SHELL: 'shell' } },
+    notification: { on: { SHELL: 'shell' } }
+  }
+});

--- a/apps/scale-shell/app/root.tsx
+++ b/apps/scale-shell/app/root.tsx
@@ -1,0 +1,18 @@
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
+
+export default function Root() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}

--- a/apps/scale-shell/app/routes/_index.tsx
+++ b/apps/scale-shell/app/routes/_index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useMachine } from '@xstate/react';
+import { navigationMachine } from '../navigationMachine';
+import { useSharedState } from 'shared-state';
+
+const LoadRemote = (scope: Promise<any>) => {
+  const Component = React.lazy(() => scope);
+  return (
+    <React.Suspense fallback="Loading...">
+      <Component />
+    </React.Suspense>
+  );
+};
+
+export default function Index() {
+  const [state, send] = useMachine(navigationMachine);
+  const shared = useSharedState();
+
+  const renderChild = () => {
+    switch (state.value) {
+      case 'produceScale':
+        return LoadRemote(import('produceScale/App'));
+      case 'colleagueMenu':
+        return LoadRemote(import('colleagueMenu/App'));
+      case 'notification':
+        return LoadRemote(import('notification/App'));
+      default:
+        return <div>Welcome to ScaleShell</div>;
+    }
+  };
+
+  return (
+    <div>
+      <nav>
+        <button onClick={() => send('PRODUCE')}>ProduceScale</button>
+        <button onClick={() => send('COLLEAGUE')}>ColleagueMenu</button>
+        <button onClick={() => send('NOTIFICATION')}>Notification</button>
+      </nav>
+      {renderChild()}
+      <div>Shared count: {shared.count}</div>
+    </div>
+  );
+}

--- a/apps/scale-shell/package.json
+++ b/apps/scale-shell/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "scale-shell",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "remix dev",
+    "build:remotes": "npm --prefix ../produce-scale run build && npm --prefix ../colleague-menu run build && npm --prefix ../notification run build && mkdir -p public/remotes/produce-scale public/remotes/colleague-menu public/remotes/notification && cp ../produce-scale/dist/assets/remoteEntry.js public/remotes/produce-scale/ && cp ../colleague-menu/dist/assets/remoteEntry.js public/remotes/colleague-menu/ && cp ../notification/dist/assets/remoteEntry.js public/remotes/notification/",
+    "build": "npm run build:remotes && remix build && vite build",
+    "start": "remix-serve build"
+  },
+  "dependencies": {
+    "@remix-run/node": "^2.0.0",
+    "@remix-run/react": "^2.0.0",
+    "@xstate/react": "^3.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "shared-state": "1.0.0",
+    "xstate": "^4.37.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "^1.0.0",
+    "@remix-run/dev": "^2.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/apps/scale-shell/remix.config.js
+++ b/apps/scale-shell/remix.config.js
@@ -1,0 +1,4 @@
+/** @type {import('@remix-run/dev').AppConfig} */
+module.exports = {
+  ignoredRouteFiles: ['**/.*']
+};

--- a/apps/scale-shell/vite.config.ts
+++ b/apps/scale-shell/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import federation from '@module-federation/vite';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    federation({
+      name: 'shell',
+      remotes: {
+        produceScale: '/remotes/produce-scale/remoteEntry.js',
+        colleagueMenu: '/remotes/colleague-menu/remoteEntry.js',
+        notification: '/remotes/notification/remoteEntry.js',
+      },
+      shared: ['react', 'react-dom', 'xstate', 'zustand'],
+    }),
+  ],
+  build: {
+    outDir: 'dist',
+    target: 'esnext',
+    rollupOptions: {
+      // mark federated modules as external so Vite doesn't try to bundle them
+      external: [
+        'produceScale/App',
+        'colleagueMenu/App',
+        'notification/App',
+      ],
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "remix-mf-root",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "build:shell": "npm --prefix apps/scale-shell run build",
+    "build:produce": "npm --prefix apps/produce-scale run build",
+    "build:colleague": "npm --prefix apps/colleague-menu run build",
+    "build:notification": "npm --prefix apps/notification run build",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^1.2.2"
+  }
+}

--- a/packages/shared-state/package.json
+++ b/packages/shared-state/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "shared-state",
+  "version": "1.0.0",
+  "main": "store.ts",
+  "dependencies": {
+    "react": "^18.2.0",
+    "zustand": "^4.4.0"
+  }
+}

--- a/packages/shared-state/store.test.ts
+++ b/packages/shared-state/store.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { useSharedState } from './store';
+
+describe('shared state store', () => {
+  it('increments the count', () => {
+    expect(useSharedState.getState().count).toBe(0);
+    useSharedState.getState().increment();
+    expect(useSharedState.getState().count).toBe(1);
+  });
+});

--- a/packages/shared-state/store.ts
+++ b/packages/shared-state/store.ts
@@ -1,0 +1,11 @@
+import create from 'zustand';
+
+interface SharedState {
+  count: number;
+  increment: () => void;
+}
+
+export const useSharedState = create<SharedState>((set) => ({
+  count: 0,
+  increment: () => set((s) => ({ count: s.count + 1 }))
+}));


### PR DESCRIPTION
## Summary
- replace webpack configs with Vite Module Federation plugin across shell and child apps
- update build scripts to use `vite build` and copy remoteEntry files into the shell
- document Vite-based Module Federation workflow
- add Vitest and sample tests for shared Zustand store and navigation machine
- switch Remix configs to CommonJS to avoid `Unexpected token 'export'` errors
- externalize remote modules in shell Vite config to prevent resolution errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aae373adc83259ad0ac0adcb1d236