### PR TITLE
chore: exclude remote modules from Vite optimization

### DIFF
--- a/apps/scale-shell/vite.config.ts
+++ b/apps/scale-shell/vite.config.ts
@@ -14,6 +14,9 @@ export default {
       shared: ['react', 'react-dom', 'xstate', 'zustand'],
     }),
   ],
+  optimizeDeps: {
+    exclude: ['produceScale/App', 'colleagueMenu/App', 'notification/App'],
+  },
   build: {
     outDir: 'dist',
     target: 'esnext',


### PR DESCRIPTION
## Summary
- avoid pre-bundling remote module federation apps by excluding them in Vite's optimizeDeps

## Testing
- `npm --prefix apps/scale-shell run build:remotes`
- `npm --prefix apps/scale-shell run dev` *(fails: Could not resolve "produceScale/App" et al.)*


------
https://chatgpt.com/codex/tasks/task_e_689ae25bf12c83258b0220fcdf13ec25