### PR TITLE
chore: bundle Remix apps with Vite

### DIFF
--- a/apps/colleague-menu/package.json
+++ b/apps/colleague-menu/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "remix dev",
-    "build": "remix build && vite build",
+    "dev": "vite dev",
+    "build": "vite build",
     "start": "remix-serve build"
   },
   "dependencies": {

--- a/apps/colleague-menu/remix.config.js
+++ b/apps/colleague-menu/remix.config.js
@@ -1,4 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  ignoredRouteFiles: ['**/.*']
+  ignoredRouteFiles: ['**/.*'],
+  future: { v2_dev: true, v2_routeConvention: true },
 };

--- a/apps/colleague-menu/vite.config.ts
+++ b/apps/colleague-menu/vite.config.ts
@@ -1,9 +1,11 @@
 import react from '@vitejs/plugin-react';
+import { vitePlugin as remix } from '@remix-run/dev';
 import { federation } from '@module-federation/vite';
 
 export default {
   plugins: [
     react(),
+    remix(),
     federation({
       name: 'colleagueMenu',
       filename: 'remoteEntry.js',

--- a/apps/notification/package.json
+++ b/apps/notification/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "remix dev",
-    "build": "remix build && vite build",
+    "dev": "vite dev",
+    "build": "vite build",
     "start": "remix-serve build"
   },
   "dependencies": {

--- a/apps/notification/remix.config.js
+++ b/apps/notification/remix.config.js
@@ -1,4 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  ignoredRouteFiles: ['**/.*']
+  ignoredRouteFiles: ['**/.*'],
+  future: { v2_dev: true, v2_routeConvention: true },
 };

--- a/apps/notification/vite.config.ts
+++ b/apps/notification/vite.config.ts
@@ -1,9 +1,11 @@
 import react from '@vitejs/plugin-react';
+import { vitePlugin as remix } from '@remix-run/dev';
 import { federation } from '@module-federation/vite';
 
 export default {
   plugins: [
     react(),
+    remix(),
     federation({
       name: 'notification',
       filename: 'remoteEntry.js',

--- a/apps/produce-scale/package.json
+++ b/apps/produce-scale/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "remix dev",
-    "build": "remix build && vite build",
+    "dev": "vite dev",
+    "build": "vite build",
     "start": "remix-serve build"
   },
   "dependencies": {

--- a/apps/produce-scale/remix.config.js
+++ b/apps/produce-scale/remix.config.js
@@ -1,4 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  ignoredRouteFiles: ['**/.*']
+  ignoredRouteFiles: ['**/.*'],
+  future: { v2_dev: true, v2_routeConvention: true },
 };

--- a/apps/produce-scale/vite.config.ts
+++ b/apps/produce-scale/vite.config.ts
@@ -1,9 +1,11 @@
 import react from '@vitejs/plugin-react';
+import { vitePlugin as remix } from '@remix-run/dev';
 import { federation } from '@module-federation/vite';
 
 export default {
   plugins: [
     react(),
+    remix(),
     federation({
       name: 'produceScale',
       filename: 'remoteEntry.js',

--- a/apps/scale-shell/package.json
+++ b/apps/scale-shell/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "remix dev",
-    "build:remotes": "npm --prefix ../produce-scale run build && npm --prefix ../colleague-menu run build && npm --prefix ../notification run build && mkdir -p public/remotes/produce-scale public/remotes/colleague-menu public/remotes/notification && cp ../produce-scale/dist/remoteEntry.js public/remotes/produce-scale/ && cp ../colleague-menu/dist/remoteEntry.js public/remotes/colleague-menu/ && cp ../notification/dist/remoteEntry.js public/remotes/notification/",
-    "build": "npm run build:remotes && remix build && vite build",
+    "dev": "vite dev",
+    "build:remotes": "npm --prefix ../produce-scale run build && npm --prefix ../colleague-menu run build && npm --prefix ../notification run build && mkdir -p public/remotes/produce-scale public/remotes/colleague-menu public/remotes/notification && cp ../produce-scale/build/client/remoteEntry.js public/remotes/produce-scale/ && cp ../colleague-menu/build/client/remoteEntry.js public/remotes/colleague-menu/ && cp ../notification/build/client/remoteEntry.js public/remotes/notification/",
+    "build": "npm run build:remotes && vite build",
     "start": "remix-serve build"
   },
   "dependencies": {

--- a/apps/scale-shell/remix.config.js
+++ b/apps/scale-shell/remix.config.js
@@ -1,4 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  ignoredRouteFiles: ['**/.*']
+  ignoredRouteFiles: ['**/.*'],
+  future: { v2_dev: true, v2_routeConvention: true },
 };

--- a/apps/scale-shell/vite.config.ts
+++ b/apps/scale-shell/vite.config.ts
@@ -1,9 +1,11 @@
 import react from '@vitejs/plugin-react';
+import { vitePlugin as remix } from '@remix-run/dev';
 import { federation } from '@module-federation/vite';
 
 export default {
   plugins: [
     react(),
+    remix(),
     federation({
       name: 'shell',
       remotes: {


### PR DESCRIPTION
## Summary
- use Remix Vite plugin in each app's Vite config
- enable Vite in Remix config files and switch scripts to `vite dev`/`vite build`
- update shell's remote build script for new output paths

## Testing
- `npm --prefix apps/scale-shell run build:remotes && npm --prefix apps/scale-shell run dev`


------
https://chatgpt.com/codex/tasks/task_e_689af15b82fc8325a5caf66f3c02608b