### PR TITLE
chore: stop sharing react from child apps

### DIFF
--- a/apps/colleague-menu/vite.config.ts
+++ b/apps/colleague-menu/vite.config.ts
@@ -12,7 +12,7 @@ export default {
       exposes: {
         './App': './app/remote.tsx',
       },
-      shared: ['react', 'react-dom', 'zustand'],
+      shared: ['zustand'],
     }),
   ],
   build: {

--- a/apps/notification/vite.config.ts
+++ b/apps/notification/vite.config.ts
@@ -12,7 +12,7 @@ export default {
       exposes: {
         './App': './app/remote.tsx',
       },
-      shared: ['react', 'react-dom', 'zustand'],
+      shared: ['zustand'],
     }),
   ],
   build: {

--- a/apps/produce-scale/vite.config.ts
+++ b/apps/produce-scale/vite.config.ts
@@ -12,7 +12,7 @@ export default {
       exposes: {
         './App': './app/remote.tsx',
       },
-      shared: ['react', 'react-dom', 'zustand'],
+      shared: ['zustand'],
     }),
   ],
   build: {

--- a/apps/scale-shell/vite.config.ts
+++ b/apps/scale-shell/vite.config.ts
@@ -13,7 +13,7 @@ export default {
         colleagueMenu: '/remotes/colleague-menu/remoteEntry.js',
         notification: '/remotes/notification/remoteEntry.js',
       },
-      shared: ['react', 'react-dom', 'xstate', 'zustand'],
+      shared: ['xstate', 'zustand'],
     }),
   ],
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- remove react and react-dom from module federation shared dependencies
- rebuild child apps and restart ScaleShell dev server

## Testing
- `npm run build:produce`
- `npm run build:colleague`
- `npm run build:notification`
- `npm --prefix apps/scale-shell run dev`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af5754cb4832599771ad5868742ab