### PR TITLE
chore: remove shared federated deps

### DIFF
--- a/apps/scale-shell/vite.config.ts
+++ b/apps/scale-shell/vite.config.ts
@@ -13,7 +13,6 @@ export default {
         colleagueMenu: '/remotes/colleague-menu/remoteEntry.js',
         notification: '/remotes/notification/remoteEntry.js',
       },
-      shared: ['xstate', 'zustand'],
     }),
   ],
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- fix shell federation config by removing shared deps

## Testing
- `npm --prefix apps/produce-scale run build`
- `npm --prefix apps/colleague-menu run build`
- `npm --prefix apps/notification run build`
- `npm --prefix apps/scale-shell run build:remotes` *(fails: cp: cannot stat '../produce-scale/dist/remoteEntry.js': No such file or directory)*
- `npm --prefix apps/scale-shell run dev -- --port 5175` *(curl checks)*
- `curl -I http://localhost:5175/remotes/produce-scale/remoteEntry.js`
- `curl -I http://localhost:5175/remotes/colleague-menu/remoteEntry.js`
- `curl -I http://localhost:5175/remotes/notification/remoteEntry.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1235416c8325b008e91fa9a6e686