### PR TITLE
fix: share shared state across remotes

### DIFF
--- a/apps/colleague-menu/vite.config.ts
+++ b/apps/colleague-menu/vite.config.ts
@@ -12,7 +12,7 @@ export default {
       exposes: {
         './App': './app/remote.tsx',
       },
-      shared: ['zustand'],
+      shared: ['zustand', 'shared-state'],
     }),
   ],
   build: {

--- a/apps/notification/vite.config.ts
+++ b/apps/notification/vite.config.ts
@@ -12,7 +12,7 @@ export default {
       exposes: {
         './App': './app/remote.tsx',
       },
-      shared: ['zustand'],
+      shared: ['zustand', 'shared-state'],
     }),
   ],
   build: {

--- a/apps/produce-scale/vite.config.ts
+++ b/apps/produce-scale/vite.config.ts
@@ -12,7 +12,7 @@ export default {
       exposes: {
         './App': './app/remote.tsx',
       },
-      shared: ['zustand'],
+      shared: ['zustand', 'shared-state'],
     }),
   ],
   build: {

--- a/apps/scale-shell/package.json
+++ b/apps/scale-shell/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite dev",
-    "build:remotes": "npm --prefix ../produce-scale run build && npm --prefix ../colleague-menu run build && npm --prefix ../notification run build && mkdir -p public/remotes/produce-scale public/remotes/colleague-menu public/remotes/notification && cp ../produce-scale/dist/remoteEntry.js public/remotes/produce-scale/ && cp ../colleague-menu/dist/remoteEntry.js public/remotes/colleague-menu/ && cp ../notification/dist/remoteEntry.js public/remotes/notification/",
+    "build:remotes": "npm --prefix ../produce-scale run build && npm --prefix ../colleague-menu run build && npm --prefix ../notification run build && mkdir -p public/remotes/produce-scale public/remotes/colleague-menu public/remotes/notification && cp ../produce-scale/build/client/remoteEntry.js public/remotes/produce-scale/ && cp ../colleague-menu/build/client/remoteEntry.js public/remotes/colleague-menu/ && cp ../notification/build/client/remoteEntry.js public/remotes/notification/",
     "build": "npm run build:remotes && vite build",
     "start": "remix-serve build"
   },

--- a/apps/scale-shell/vite.config.ts
+++ b/apps/scale-shell/vite.config.ts
@@ -13,7 +13,7 @@ export default {
         colleagueMenu: '/remotes/colleague-menu/remoteEntry.js',
         notification: '/remotes/notification/remoteEntry.js',
       },
-      shared: ['xstate', 'zustand'],
+      shared: ['shared-state'],
     }),
   ],
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- share `shared-state` module across shell and remotes
- copy remote bundles from updated build output

## Testing
- `npm --prefix apps/produce-scale run build`
- `npm --prefix apps/colleague-menu run build`
- `npm --prefix apps/notification run build`
- `npm --prefix apps/scale-shell run build:remotes`
- `npm --prefix apps/scale-shell run dev -- --port 5175` (curl checks)
- `curl -I http://localhost:5175/remotes/produce-scale/remoteEntry.js`
- `curl -I http://localhost:5175/remotes/colleague-menu/remoteEntry.js`
- `curl -I http://localhost:5175/remotes/notification/remoteEntry.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1235416c8325b008e91fa9a6e686