### PR TITLE
Enable predictable action args in navigation machine

### DIFF
--- a/apps/scale-shell/app/navigationMachine.test.ts
+++ b/apps/scale-shell/app/navigationMachine.test.ts
@@ -4,6 +4,9 @@ import { navigationMachine } from './navigationMachine';
 
 describe('navigation state machine', () => {
   it('navigates between shell and produce scale', () => {
+    // ensure machine has predictable action arguments enabled
+    expect(navigationMachine.options?.predictableActionArguments).toBe(true);
+
     const service = interpret(navigationMachine).start();
     expect(service.state.value).toBe('shell');
     service.send('PRODUCE');

--- a/apps/scale-shell/app/navigationMachine.ts
+++ b/apps/scale-shell/app/navigationMachine.ts
@@ -1,18 +1,21 @@
 import { createMachine } from 'xstate';
 
-export const navigationMachine = createMachine({
-  id: 'navigation',
-  initial: 'shell',
-  states: {
-    shell: {
-      on: {
-        PRODUCE: 'produceScale',
-        COLLEAGUE: 'colleagueMenu',
-        NOTIFICATION: 'notification'
-      }
-    },
-    produceScale: { on: { SHELL: 'shell' } },
-    colleagueMenu: { on: { SHELL: 'shell' } },
-    notification: { on: { SHELL: 'shell' } }
-  }
-});
+export const navigationMachine = createMachine(
+  {
+    id: 'navigation',
+    initial: 'shell',
+    states: {
+      shell: {
+        on: {
+          PRODUCE: 'produceScale',
+          COLLEAGUE: 'colleagueMenu',
+          NOTIFICATION: 'notification'
+        }
+      },
+      produceScale: { on: { SHELL: 'shell' } },
+      colleagueMenu: { on: { SHELL: 'shell' } },
+      notification: { on: { SHELL: 'shell' } }
+    }
+  },
+  { predictableActionArguments: true }
+);

--- a/apps/scale-shell/src/navigationMachine.ts
+++ b/apps/scale-shell/src/navigationMachine.ts
@@ -1,18 +1,21 @@
 import { createMachine } from 'xstate';
 
-export const navigationMachine = createMachine({
-  id: 'navigation',
-  initial: 'shell',
-  states: {
-    shell: {
-      on: {
-        PRODUCE: 'produceScale',
-        COLLEAGUE: 'colleagueMenu',
-        NOTIFICATION: 'notification'
-      }
-    },
-    produceScale: { on: { SHELL: 'shell' } },
-    colleagueMenu: { on: { SHELL: 'shell' } },
-    notification: { on: { SHELL: 'shell' } }
-  }
-});
+export const navigationMachine = createMachine(
+  {
+    id: 'navigation',
+    initial: 'shell',
+    states: {
+      shell: {
+        on: {
+          PRODUCE: 'produceScale',
+          COLLEAGUE: 'colleagueMenu',
+          NOTIFICATION: 'notification'
+        }
+      },
+      produceScale: { on: { SHELL: 'shell' } },
+      colleagueMenu: { on: { SHELL: 'shell' } },
+      notification: { on: { SHELL: 'shell' } }
+    }
+  },
+  { predictableActionArguments: true }
+);


### PR DESCRIPTION
## Summary
- enable predictableActionArguments for navigation machine in src and app folders
- verify navigationMachine exposes predictableActionArguments via tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b1e434f0483259cbd0f1e8843012d