### PR TITLE
chore: update navigation machine config

### DIFF
--- a/apps/scale-shell/app/navigationMachine.test.ts
+++ b/apps/scale-shell/app/navigationMachine.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { interpret } from 'xstate';
-import { navigationMachine } from './navigationMachine';
+import { navigationMachine } from '../src/navigationMachine';
 
 describe('navigation state machine', () => {
   it('navigates between shell and produce scale', () => {

--- a/apps/scale-shell/app/navigationMachine.ts
+++ b/apps/scale-shell/app/navigationMachine.ts
@@ -1,18 +1,1 @@
-import { createMachine } from 'xstate';
-
-export const navigationMachine = createMachine({
-  id: 'navigation',
-  initial: 'shell',
-  states: {
-    shell: {
-      on: {
-        PRODUCE: 'produceScale',
-        COLLEAGUE: 'colleagueMenu',
-        NOTIFICATION: 'notification'
-      }
-    },
-    produceScale: { on: { SHELL: 'shell' } },
-    colleagueMenu: { on: { SHELL: 'shell' } },
-    notification: { on: { SHELL: 'shell' } }
-  }
-});
+export { navigationMachine } from '../src/navigationMachine';

--- a/apps/scale-shell/src/navigationMachine.ts
+++ b/apps/scale-shell/src/navigationMachine.ts
@@ -1,18 +1,21 @@
 import { createMachine } from 'xstate';
 
-export const navigationMachine = createMachine({
-  id: 'navigation',
-  initial: 'shell',
-  states: {
-    shell: {
-      on: {
-        PRODUCE: 'produceScale',
-        COLLEAGUE: 'colleagueMenu',
-        NOTIFICATION: 'notification'
-      }
-    },
-    produceScale: { on: { SHELL: 'shell' } },
-    colleagueMenu: { on: { SHELL: 'shell' } },
-    notification: { on: { SHELL: 'shell' } }
+export const navigationMachine = createMachine(
+  {
+    id: 'navigation',
+    predictableActionArguments: true,
+    initial: 'shell',
+    states: {
+      shell: {
+        on: {
+          PRODUCE: 'produceScale',
+          COLLEAGUE: 'colleagueMenu',
+          NOTIFICATION: 'notification'
+        }
+      },
+      produceScale: { on: { SHELL: 'shell' } },
+      colleagueMenu: { on: { SHELL: 'shell' } },
+      notification: { on: { SHELL: 'shell' } }
+    }
   }
-});
+);


### PR DESCRIPTION
## Summary
- re-export navigationMachine from shared src
- enable predictableActionArguments for navigation state machine
- adapt test to import configured navigation machine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b1e579130832598aa0c92e57ccf73