### PR TITLE
feat: add CJS build for shared-state

### DIFF
--- a/packages/shared-state/dist/index.cjs
+++ b/packages/shared-state/dist/index.cjs
@@ -35,7 +35,7 @@ __export(shared_state_exports, {
 module.exports = __toCommonJS(shared_state_exports);
 
 // store.ts
-var import_zustand = __toESM(require("zustand"), 1);
+var import_zustand = __toESM(require("zustand"));
 var useSharedState = (0, import_zustand.default)((set) => ({
   count: 0,
   increment: () => set((s) => ({ count: s.count + 1 }))

--- a/packages/shared-state/package.json
+++ b/packages/shared-state/package.json
@@ -2,7 +2,6 @@
   "name": "shared-state",
   "version": "1.0.0",
   "main": "./dist/index.cjs",
-  "type": "module",
   "exports": {
     ".": {
       "require": "./dist/index.cjs",

--- a/packages/shared-state/tsup.config.ts
+++ b/packages/shared-state/tsup.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
   outDir: 'dist',
   dts: false,
   clean: true,
+  outExtension: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+  }),
 });


### PR DESCRIPTION
## Summary
- allow shared-state to emit CommonJS bundle with `.cjs`
- expose CommonJS and ESM entries and drop module type

## Testing
- `npm --prefix packages/shared-state run build`
- `npm install`
- `npm test` *(fails: Expected "}" but found ")" in navigationMachine.ts)*


------
https://chatgpt.com/codex/tasks/task_e_689b25dad15c832581103a306f640331