### PR TITLE
feat(shared-state): add dual module exports

### DIFF
--- a/packages/shared-state/dist/index.cjs
+++ b/packages/shared-state/dist/index.cjs
@@ -35,7 +35,7 @@ __export(shared_state_exports, {
 module.exports = __toCommonJS(shared_state_exports);
 
 // store.ts
-var import_zustand = __toESM(require("zustand"));
+var import_zustand = __toESM(require("zustand"), 1);
 var useSharedState = (0, import_zustand.default)((set) => ({
   count: 0,
   increment: () => set((s) => ({ count: s.count + 1 }))

--- a/packages/shared-state/package.json
+++ b/packages/shared-state/package.json
@@ -1,9 +1,14 @@
 {
   "name": "shared-state",
   "version": "1.0.0",
-  "main": "./dist/index.js",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "exports": {
-     ".": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
   },
   "scripts": {
     "build": "tsup"


### PR DESCRIPTION
## Summary
- configure shared-state to export both CommonJS and ES modules
- ensure package.json includes explicit main, module, and exports mappings
- rebuild shared-state package to generate CommonJS output

## Testing
- `npm --prefix packages/shared-state run build`
- `node -e "import('shared-state').then(m=>console.log('pkg esm ok', Object.keys(m)))"`
- `node -e "console.log('pkg cjs ok', Object.keys(require('shared-state')))"`
- `npm test` *(fails: Expected "}" but found ")" in apps/scale-shell/src/navigationMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689b6bc2b37483259c27c6c64298f867