### PR TITLE
refactor(shared-state): replace zustand with nanostores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,6 +1219,25 @@
         "pathe": "^1.1.2"
       }
     },
+    "node_modules/@nanostores/react": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nanostores/react/-/react-1.0.0.tgz",
+      "integrity": "sha512-eDduyNy+lbQJMg6XxZ/YssQqF6b4OXMFEZMYKPJCCmBevp1lg0g+4ZRi94qGHirMtsNfAWKNwsjOhC+q1gvC+A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "nanostores": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^1.0.0",
+        "react": ">=18.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6472,6 +6491,21 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nanostores": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.0.1.tgz",
+      "integrity": "sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -10726,8 +10760,9 @@
     "packages/shared-state": {
       "version": "1.0.0",
       "dependencies": {
-        "react": "^18.2.0",
-        "zustand": "^4.4.0"
+        "@nanostores/react": "^1.0.0",
+        "nanostores": "^1.0.1",
+        "react": "^18.2.0"
       },
       "devDependencies": {
         "tsup": "^7.2.0",

--- a/packages/shared-state/dist/index.cjs
+++ b/packages/shared-state/dist/index.cjs
@@ -1,9 +1,7 @@
 "use strict";
-var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;
-var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
 var __export = (target, all) => {
   for (var name in all)
@@ -17,14 +15,6 @@ var __copyProps = (to, from, except, desc) => {
   }
   return to;
 };
-var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
-  // If the importer is in node compatibility mode or this is not an ESM
-  // file that has been converted to a CommonJS file using a Babel-
-  // compatible transform (i.e. "__esModule" has not been set), then set
-  // "default" to the CommonJS "module.exports" for node compatibility.
-  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
-  mod
-));
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
 // index.ts
@@ -35,11 +25,16 @@ __export(shared_state_exports, {
 module.exports = __toCommonJS(shared_state_exports);
 
 // store.ts
-var import_zustand = __toESM(require("zustand"));
-var useSharedState = (0, import_zustand.default)((set) => ({
-  count: 0,
-  increment: () => set((s) => ({ count: s.count + 1 }))
-}));
+var import_nanostores = require("nanostores");
+var import_react = require("@nanostores/react");
+var countStore = (0, import_nanostores.atom)(0);
+var increment = () => {
+  countStore.set(countStore.get() + 1);
+};
+function useSharedState() {
+  const count = (0, import_react.useStore)(countStore);
+  return { count, increment };
+}
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
   useSharedState

--- a/packages/shared-state/dist/index.js
+++ b/packages/shared-state/dist/index.js
@@ -1,9 +1,14 @@
 // store.ts
-import create from "zustand";
-var useSharedState = create((set) => ({
-  count: 0,
-  increment: () => set((s) => ({ count: s.count + 1 }))
-}));
+import { atom } from "nanostores";
+import { useStore } from "@nanostores/react";
+var countStore = atom(0);
+var increment = () => {
+  countStore.set(countStore.get() + 1);
+};
+function useSharedState() {
+  const count = useStore(countStore);
+  return { count, increment };
+}
 export {
   useSharedState
 };

--- a/packages/shared-state/package.json
+++ b/packages/shared-state/package.json
@@ -1,16 +1,22 @@
 {
   "name": "shared-state",
   "version": "1.0.0",
-  "main": "./dist/index.js",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "exports": {
-     ".": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
   },
   "scripts": {
     "build": "tsup"
   },
   "dependencies": {
     "react": "^18.2.0",
-    "zustand": "^4.4.0"
+    "nanostores": "^1.0.1",
+    "@nanostores/react": "^1.0.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/packages/shared-state/store.test.ts
+++ b/packages/shared-state/store.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { useSharedState } from './store';
+import { countStore, increment } from './store';
 
 describe('shared state store', () => {
   it('increments the count', () => {
-    expect(useSharedState.getState().count).toBe(0);
-    useSharedState.getState().increment();
-    expect(useSharedState.getState().count).toBe(1);
+    expect(countStore.get()).toBe(0);
+    increment();
+    expect(countStore.get()).toBe(1);
   });
 });

--- a/packages/shared-state/store.ts
+++ b/packages/shared-state/store.ts
@@ -1,11 +1,13 @@
-import create from 'zustand';
+import { atom } from 'nanostores';
+import { useStore } from '@nanostores/react';
 
-interface SharedState {
-  count: number;
-  increment: () => void;
+export const countStore = atom(0);
+
+export const increment = () => {
+  countStore.set(countStore.get() + 1);
+};
+
+export function useSharedState() {
+  const count = useStore(countStore);
+  return { count, increment };
 }
-
-export const useSharedState = create<SharedState>((set) => ({
-  count: 0,
-  increment: () => set((s) => ({ count: s.count + 1 }))
-}));


### PR DESCRIPTION
## Summary
- switch shared-state hook from zustand to nanostores
- update dependencies and rebuild dual ESM/CJS outputs

## Testing
- `npm --prefix packages/shared-state run build`
- `node -e "import('shared-state').then(m=>console.log('pkg esm ok', Object.keys(m)))"`
- `node -e "console.log('pkg cjs ok', Object.keys(require('shared-state')))"`
- `npm test` *(fails: Expected "}" but found ")" in apps/scale-shell/src/navigationMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689b6bc2b37483259c27c6c64298f867